### PR TITLE
Add BaseSet

### DIFF
--- a/packages/BaseSet
+++ b/packages/BaseSet
@@ -1,0 +1,1 @@
+https://github.com/ropensci/BaseSet


### PR DESCRIPTION
This package has some suggested packages in Bioconductor. 
In CRAN sometimes some packages are not present:

> Version: 0.9.0
> Check: package dependencies
> Result: NOTE
>   Package suggested but not available for checking: ‘reactome.db’
> Flavors: [r-release-macos-arm64](https://www.r-project.org/nosvn/R.check/r-release-macos-arm64/BaseSet-00check.html), [r-release-macos-x86_64](https://www.r-project.org/nosvn/R.check/r-release-macos-x86_64/BaseSet-00check.html)

Testing how it handles this, next I'll try a Bioconductor package.