### PR TITLE
Remove packages/arrow for now

### DIFF
--- a/packages/arrow
+++ b/packages/arrow
@@ -1,6 +1,0 @@
-{
-  "package": "arrow",
-  "url": "https://github.com/apache/arrow",
-  "subdir": "r",
-  "branch": "*release"
-}


### PR DESCRIPTION
I thought just a tag would have been good enough, but the *release branch apparently needs an actual release: https://github.com/r-universe/r-releases/actions/runs/8127177735/job/22211728431